### PR TITLE
v0.1.2

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -2,7 +2,7 @@
     "manifest_version": 3,
     "name": "BetterTabTool",
     "description": "A tool to help you manage your tabs and windows efficiently.",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "minimum_chrome_version": "120",
     "permissions": [
         "tabs",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
     "name": "bettertabtool",
-    "version": "0.1.1",
+    "version": "0.1.2",
     "main": "index.js",
     "scripts": {
         "build": "webpack --mode production",

--- a/src/background/services/contextmenu.service.ts
+++ b/src/background/services/contextmenu.service.ts
@@ -219,7 +219,8 @@ export class ContextMenuService {
      * @returns {Promise<void>} A promise that resolves when the context menu items are updated.
      */
     private updateWindowContextMenus = async (): Promise<void> => {
-        const windows = await chrome.windows.getAll({ populate: true });
+        // Filter to only get normal windows
+        const windows = await chrome.windows.getAll({ populate: true, windowTypes: ['normal'] });
         const windowIdToDescription = new Map<number, string>();
 
         windows.forEach((window: chrome.windows.Window) => {

--- a/src/background/services/tab.service.ts
+++ b/src/background/services/tab.service.ts
@@ -126,12 +126,16 @@ export class TabService {
             return; // Nothing to merge
         }
 
-        // Merge all windows into the current window
+        // Merge all "normal" windows into the current window
         const targetWindow = await chrome.windows.getCurrent();
+        if (targetWindow.type !== 'normal') {
+            // console.log('Target window is not normal, nothing to merge.');
+            return; // Nothing to merge
+        }
         // console.log(`Target window ID: ${targetWindow.id}`);
 
         for (const win of windows) {
-            if (win.id === targetWindow.id) continue; // Skip the target window
+            if (win.id === targetWindow.id || win.type !== 'normal') continue; // Skip the target window and non-normal windows
 
             // console.log(`Processing window with ID: ${win.id}`);
 
@@ -152,7 +156,6 @@ export class TabService {
                     if (wasTabPinned || wasTabMuted) {
                         chrome.tabs.update(tab.id!, { pinned: wasTabPinned, muted: wasTabMuted });
                     }
-
                 }
             }
 

--- a/src/background/services/tab.service.ts
+++ b/src/background/services/tab.service.ts
@@ -141,11 +141,18 @@ export class TabService {
             // Move each ungrouped tab from the current window to the target window
             for (const tab of win.tabs || []) {
                 if (tab.groupId === chrome.tabGroups.TAB_GROUP_ID_NONE) {
+                    let wasTabPinned = tab.pinned ?? false;
+                    let wasTabMuted = tab.mutedInfo?.muted ?? false;
                     // console.log(`Moving tab ID: ${tab.id} from window ID: ${win.id} to target window ID: ${targetWindow.id}`);
                     await chrome.tabs.move(tab.id!, {
                         windowId: targetWindow.id,
                         index: -1,
                     });
+                    // Retain pinned and muted state
+                    if (wasTabPinned || wasTabMuted) {
+                        chrome.tabs.update(tab.id!, { pinned: wasTabPinned, muted: wasTabMuted });
+                    }
+
                 }
             }
 


### PR DESCRIPTION
- Bumped version to 0.1.2
- Fixed issue where pinned and muted states were not retained when merging tabs
- Fixed issue where "merge windows” included window types other than "normal"
- Fixed issue where context menu window options included window types other than "normal"